### PR TITLE
updated  Route Model and TypeDefs for multiple point geometry to work

### DIFF
--- a/server/models/Route.js
+++ b/server/models/Route.js
@@ -4,7 +4,7 @@ const routeSchema = new Schema(
     {
         geometry:[
             {
-                type: Number
+                type: String
             }
         ],
         description:{

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -17,7 +17,7 @@ type Auth {
 
 type Route {
   _id: ID
-  geometry:[Int]!
+  geometry:[String]!
   description:String
   difficultyLevel:Int!
   title:String!
@@ -56,8 +56,7 @@ type Mutation {
         ): Auth
     addRoute(
       userId: String!
-      routeName: String!
-      geometry: [Int]!
+      geometry: [String]!
       description: String!
       title: String
       difficultyLevel: Int!


### PR DESCRIPTION
changed the type of geometry to say String because if you have multiple points such as this:

"geometry": [
    [-82.8212915979806,28.05773940437285],
    [-82.82967443530357,28.055378742072214],
    [-82.81666529308482,28.055207261232812]
            ],
it will not see this as an INT, therefore you need to make it look like this in order to store:

"geometry": [
    "[-82.8212915979806,28.05773940437285]",
    "[-82.82967443530357,28.055378742072214]",
    "[-82.81666529308482,28.055207261232812]"
            ],

also removed routeName because we added title in the typeDef mutation. thanks for reading you're the best!